### PR TITLE
Add osx app

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,12 @@ source:
   sha256: c942e034ed97de2bb8aadb9aca17810543185a74ec8490819b4a730ad3d4df0a
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - nexpy = nexpy.nexpygui:main
   noarch: "python"
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  osx_is_app: True
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/NeXpy-{{ version }}.tar.gz"
   sha256: c942e034ed97de2bb8aadb9aca17810543185a74ec8490819b4a730ad3d4df0a
+  patches:
+    - toolbar-fix.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
     - nexpy = nexpy.nexpygui:main
   noarch: "python"
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
-  osx_is_app: True
 
 requirements:
   host:

--- a/recipe/toolbar-fix.patch
+++ b/recipe/toolbar-fix.patch
@@ -1,0 +1,18 @@
+commit 6e6c67d52dc943981204a073f6a15be21a1c668d
+Author: Tom Schoonjans <Tom.Schoonjans@diamond.ac.uk>
+Date:   Thu Nov 7 09:07:24 2019 +0000
+
+    Fix toolbar on macOS
+
+diff --git a/src/nexpy/gui/consoleapp.py b/src/nexpy/gui/consoleapp.py
+index eb5c29a..bc4bc34 100644
+--- a/src/nexpy/gui/consoleapp.py
++++ b/src/nexpy/gui/consoleapp.py
+@@ -360,7 +360,6 @@ class NXConsoleApp(JupyterApp, JupyterConsoleApp):
+ 
+         # draw the window
+         self.window.show()
+-        self.window.raise_()
+ 
+         # Start the application main loop.
+         self.app.exec_()


### PR DESCRIPTION
This switch ensures that the package is built as an OSX app, which ensures the menus are accessible on launch. I believe that the switch is ignored in other systems.