### PR TITLE
Require nexusformat v0.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - h5py
     - ipython
     - matplotlib
-    - nexusformat
+    - nexusformat >=0.5.0
     - numpy
     - pillow
     - python


### PR DESCRIPTION
* It is important to trigger an update of the nexusformat package to be compatible with this version.